### PR TITLE
Fix xss bug in search results.

### DIFF
--- a/views/search_results.erb
+++ b/views/search_results.erb
@@ -27,7 +27,7 @@
   <form role="form" action="/search" method="GET">
     <div class="col-lg-8" style="text-align:center; padding-right:0px;">
       <div class="form-group input-group" style="text-align:center;">
-        <input type="text" class="form-control" placeholder="Search Query" id="searchInput" name="searchInput" value="<%=@q%>">
+        <input type="text" class="form-control" placeholder="Search Query" id="searchInput" name="searchInput" value="<%=h(@q)%>">
         <span class="input-group-btn">
           <button class="btn btn-default" type="submit">
             <i class="fa fa-search"></i>


### PR DESCRIPTION
This PR should fix a simple XSS bug that could occur due to untrusted HTML entities being reflected in the `value` field of the search input.

To reproduce, search for `"><script>alert(1)</script>`:

<img width="1440" alt="screen shot 2016-12-22 at 11 24 31 am" src="https://cloud.githubusercontent.com/assets/1148127/21421908/e42fdf0a-c83d-11e6-82ee-b69c44334b7d.png">

With this PR applied, this simple PoC should no longer be possible:

<img width="1440" alt="screen shot 2016-12-22 at 11 20 27 am" src="https://cloud.githubusercontent.com/assets/1148127/21421943/120874fa-c83e-11e6-856e-eab58e60a8c7.png">
