### PR TITLE
Allow newer Ruby versions to be used.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '> 2.1.2'
 
 gem "sinatra", '~> 1.4.6'
 gem "thin", '~> 1.6.4'


### PR DESCRIPTION
The documentation at http://vulnreport.io/documentation shows that Ruby versions 2.1 and newer can be used, however, when running `bundle install` with the current `Gemfile` it will error out with:

```
Your Ruby version is 2.3.3, but your Gemfile specified 2.1.2
```

Modifying the version constraint to `ruby '> 2.1.2'` allows for installation on a newer ruby version.

FWIW, the little bit of testing I have done doesn't show any problems running on Ruby 2.3.3.