### PR TITLE
[WIP] update gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,33 +1,33 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.6.2'
 
-gem "sinatra", '~> 1.4.6'
-gem "thin", '~> 1.6.4'
+gem "sinatra", '~> 1.4.8'
+gem "thin", '~> 1.7.2'
 gem "data_mapper", '~> 1.2.0'
 gem "dm-postgres-adapter", '~> 1.2.0'
-gem "ruby-saml", "~> 1.0.0"
+gem "ruby-saml", "~> 1.10.2"
 gem "chronic", '~> 0.10.2'
-gem "savon", '~> 2.11.1'
-gem "rubyzip", '~> 1.2.0'
-gem "nokogiri", '~> 1.6.7.2'
-gem "activesupport"
-gem "redis", '~> 3.3.0'
-gem "json", '~> 1.8.3'
-gem "rack_csrf", '~> 2.5.0'
+gem "savon", '~> 2.12.0' # 2.12.0: drop support for ruby 2.1 and below
+gem "rubyzip", '~> 1.2.2' # 1.2.2: seems tehre are some breking change
+gem "nokogiri", '~> 1.10.3' # several minor version come with Backwards incompatibilities for ruby below 2.2
+gem "activesupport", '~> 5.2.3'
+gem "redis", '~> 4.1.1' # 4.0 come with Backwards incompatibilities for some methods and stntax but also for ruby below 2.2.2
+gem "json", '~> 2.2.0' # 2.0.0 drop support for ruby < 2.0
+gem "rack_csrf", '~> 2.6.0'
 gem "rack-ssl", '~> 1.4.1'
-gem "rufus-scheduler", '~> 3.2.0'
-gem 'pony', '~> 1.11'
-gem 'multipart-post', '~> 2.0.0'
-gem 'pg', '~> 0.18.4'
+gem "rufus-scheduler", '~> 3.6.0' # 3.5.0 drops support of some methods
+gem 'pony', '~> 1.13.1' # no changelog
+gem 'multipart-post', '~> 2.1.1'
+gem 'pg', '~> 1.1.4' # many backward major incompatibilities
 gem 'rforce', '~> 0.13'
 gem 'xml-simple', '~> 1.1.5'
-gem 'httparty', '~> 0.13.7'
-gem "dotenv", '~> 2.1.1'
-gem 'rollbar', '~> 2.10.0'
-gem 'yard', '0.8.7.6'
-gem 'yard-dm', '0.1.1'
-gem 'yard-sinatra', '1.0.0'
-gem 'eventmachine', '1.0.7'
-gem "wkhtmltopdf-heroku"
-gem "pdfkit", '~> 0.8.2'
+gem 'httparty', '~> 0.17.0' # 0.15.0: ruby 2.0+
+gem "dotenv", '~> 2.7.2' # potential breaking changes
+gem 'rollbar', '~> 2.19.4' # lot of changes but didn't see any breaking changes with a very quick look
+gem 'yard', '~> 0.9.19' # Breaking Change with templates
+gem 'yard-dm', '~> 0.1.1' # unneeded if a gemspec is built
+gem 'yard-sinatra', '~> 1.0.0'
+gem 'eventmachine', '~> 1.2.7'
+gem "wkhtmltopdf-heroku", '~> 2.12.4.0'
+gem "pdfkit", '~> 0.8.4.1' # 0.8.4: Removed support for Ruby < 2.2


### PR DESCRIPTION
I updated the Gemfile of course since it was not updated for 2 years there are many conflicts and breakings, I indicatd the major breakings changes in comment from version upgrade but there is also conflicts between dependencies.

```
$ bundle install 
Fetching gem metadata from https://rubygems.org/............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "json":
  In Gemfile:
    json (~> 2.2.0)

    data_mapper (~> 1.2.0) was resolved to 1.2.0, which depends on
      dm-serializer (~> 1.2.0) was resolved to 1.2.0, which depends on
        json (~> 1.5.4)

Bundler could not find compatible versions for gem "rack":
  In Gemfile:
    rack-ssl (~> 1.4.1) was resolved to 1.4.1, which depends on
      rack

    rack_csrf (~> 2.6.0) was resolved to 2.6.0, which depends on
      rack (>= 1.1.0)

    sinatra (~> 1.4.8) was resolved to 1.4.8, which depends on
      rack (~> 1.5)

    thin (~> 1.7.2) was resolved to 1.7.2, which depends on
      rack (>= 1, < 3)
```

Anyway it needs an upgrade since #31 shows dependencies are already broken.